### PR TITLE
feat(extends): add shell-regex and github-actions-regex custom managers

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,10 +4,12 @@
 		"config:best-practices",
 		"github>naa0yama/renovate-config//extends/docker-regex",
 		"github>naa0yama/renovate-config//extends/docker",
+		"github>naa0yama/renovate-config//extends/github-actions-regex",
 		"github>naa0yama/renovate-config//extends/mise",
 		"github>naa0yama/renovate-config//extends/npm",
 		"github>naa0yama/renovate-config//extends/python",
-		"github>naa0yama/renovate-config//extends/rust"
+		"github>naa0yama/renovate-config//extends/rust",
+		"github>naa0yama/renovate-config//extends/shell-regex"
 	],
 	"labels": [
 		"renovate",
@@ -54,6 +56,12 @@
 				"devDependencies"
 			],
 			"separateMinorPatch": false
+		},
+		{
+			"description": "Group mise CLI version updates across all file types",
+			"groupName": "mise",
+			"matchPackageNames": ["jdx/mise"],
+			"matchManagers": ["custom.regex"]
 		}
 	],
 	"patch": {

--- a/extends/github-actions-regex.json
+++ b/extends/github-actions-regex.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"customManagers": [
+		{
+			"description": "GitHub Actions with: version pinning (automerge=true)",
+			"customType": "regex",
+			"managerFilePatterns": ["/.github/workflows/.+\\.ya?ml$/"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s+automerge=true\\s*\\n\\s+version:\\s+(?<currentValue>\\S+)"
+			],
+			"depTypeTemplate": "gha-version-automerge"
+		},
+		{
+			"description": "GitHub Actions with: version pinning (automerge=false or unspecified)",
+			"customType": "regex",
+			"managerFilePatterns": ["/.github/workflows/.+\\.ya?ml$/"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+automerge=false)?\\s*\\n\\s+version:\\s+(?<currentValue>\\S+)"
+			],
+			"depTypeTemplate": "gha-version"
+		}
+	],
+	"packageRules": [
+		{
+			"description": "Custom managers (GHA version) - Auto-merge disabled by default",
+			"matchManagers": ["custom.regex"],
+			"matchDepTypes": ["gha-version"],
+			"automerge": false
+		},
+		{
+			"description": "Custom managers (GHA version) - Auto-merge for automerge=true",
+			"matchDepTypes": ["gha-version-automerge"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		}
+	]
+}

--- a/extends/shell-regex.json
+++ b/extends/shell-regex.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"customManagers": [
+		{
+			"description": "Shell script dependencies with automerge=true",
+			"customType": "regex",
+			"managerFilePatterns": ["/.+\\.sh$/"],
+			"matchStrings": [
+				"## renovate: datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s+automerge=true\\s*\\n\\S+_VERSION=\"(?<currentValue>[^\"]+)\""
+			],
+			"depTypeTemplate": "shell-automerge"
+		},
+		{
+			"description": "Shell script dependencies with automerge=false or unspecified",
+			"customType": "regex",
+			"managerFilePatterns": ["/.+\\.sh$/"],
+			"matchStrings": [
+				"## renovate: datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+automerge=false)?\\s*\\n\\S+_VERSION=\"(?<currentValue>[^\"]+)\""
+			],
+			"depTypeTemplate": "shell"
+		}
+	],
+	"packageRules": [
+		{
+			"description": "Custom managers (Shell) - Auto-merge disabled by default",
+			"matchManagers": ["custom.regex"],
+			"matchDepTypes": ["shell"],
+			"automerge": false
+		},
+		{
+			"description": "Custom managers (Shell) - Auto-merge for automerge=true",
+			"matchDepTypes": ["shell-automerge"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		}
+	]
+}


### PR DESCRIPTION
## Summary

- Add `extends/shell-regex.json`: custom manager for shell scripts (`*.sh`) matching `## renovate:` comment + `\S+_VERSION="<value>"` pattern
- Add `extends/github-actions-regex.json`: custom manager for GitHub Actions workflows matching `# renovate:` comment + `version: <value>` in `with:` blocks
- Update `default.json`: add new extends + grouping rule to collect all `jdx/mise` updates across file types into a single PR

## Background

`boilerplate-rust` now pins the mise CLI version in three places:
- `.devcontainer/postStartCommand.sh` (`MISE_PINNED_VERSION="2026.4.18"`)
- `.github/workflows/rust-ci.yaml` (x2, `version: 2026.4.18`)
- `.github/workflows/tagpr.yaml` (`version: 2026.4.18`)

These use `versioning=calver:YYYY.M.D` because mise uses calendar versioning (`YYYY.M.D`).
The grouping rule ensures all four locations are bumped in a single PR.

## Test plan

- [ ] Renovate dry-run detects `jdx/mise` in all target files
- [ ] All 4 locations are grouped into one PR
- [ ] `automerge=true` with calver correctly classifies year-change as major (no automerge) and month/day-change as minor/patch (automerge)