### PR TITLE
fix(extends/rust): add separateMinorPatch false to rust group

### DIFF
--- a/extends/rust.json
+++ b/extends/rust.json
@@ -20,7 +20,8 @@
 			"matchDepNames": [
 				"rust"
 			],
-			"groupName": "rust"
+			"groupName": "rust",
+			"separateMinorPatch": false
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- `extends/rust.json` の rust グループルールに `separateMinorPatch: false` を追加
- `default.json` でグローバルに `separateMinorPatch: true` が設定されているため、rust の minor/patch 更新が別 PR として作成されていた
- この修正により、同一 `groupName: rust` 内の minor・patch 更新が1つの PR にまとめられる

## 関連

- https://github.com/naa0yama/dna-assistant/pull/85 (patch 更新 PR)
- https://github.com/naa0yama/dna-assistant/pull/10 (minor 更新 PR)

## Test plan

- [ ] CI の `renovate-config-validator` が PASS すること
- [ ] 次回 Renovate 実行時に rust の minor/patch 更新が単一 PR にまとまること