### PR TITLE
feat(extends/rust): add Rust crate grouping rules

### DIFF
--- a/extends/rust.json
+++ b/extends/rust.json
@@ -22,6 +22,98 @@
 			],
 			"groupName": "rust",
 			"separateMinorPatch": false
+		},
+		{
+			"description": "Group clap crates (clap_complete depends on clap, same version releases)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"clap"
+			],
+			"matchPackageNames": [
+				"/^clap[_-]/"
+			],
+			"groupName": "group:clap"
+		},
+		{
+			"description": "Group OpenTelemetry crates (same release cycle, mutual dependencies)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"opentelemetry",
+				"tracing-opentelemetry"
+			],
+			"matchPackageNames": [
+				"/^opentelemetry-/",
+				"/^opentelemetry_/"
+			],
+			"groupName": "group:opentelemetry"
+		},
+		{
+			"description": "Group tracing crates (tracing-subscriber and tracing-mock depend on tracing)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"tracing",
+				"tracing-subscriber",
+				"tracing-mock"
+			],
+			"groupName": "group:tracing"
+		},
+		{
+			"description": "Group serde crates (serde_json and serde_yml depend on serde)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"serde"
+			],
+			"matchPackageNames": [
+				"/^serde_/",
+				"/^serde-/"
+			],
+			"groupName": "group:serde"
+		},
+		{
+			"description": "Group assert_cmd and predicates (assert_cmd depends on predicates)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"assert_cmd",
+				"predicates"
+			],
+			"matchPackageNames": [
+				"/^predicates/"
+			],
+			"groupName": "group:assert_cmd"
+		},
+		{
+			"description": "Group ratatui and crossterm (ratatui depends on crossterm as backend)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"ratatui",
+				"crossterm"
+			],
+			"groupName": "group:ratatui"
+		},
+		{
+			"description": "Group tokio crates (tokio-stream and tokio-util depend on tokio)",
+			"matchDatasources": [
+				"crate"
+			],
+			"matchDepNames": [
+				"tokio"
+			],
+			"matchPackageNames": [
+				"/^tokio-/"
+			],
+			"groupName": "group:tokio"
 		}
 	]
 }


### PR DESCRIPTION
## 概要

`extends/rust.json` に Rust クレートのグルーピングルールを追加する。

依存関係のあるクレートをまとめることで Renovate の PR 数を削減する。
グルーピング基準は「バージョン番号の一致」ではなく「依存関係の有無」。

- **group:clap** — `clap` + `clap[_-]*`（clap_complete, clap_mangen 等）
- **group:opentelemetry** — `opentelemetry` + `opentelemetry[-_]*` + `tracing-opentelemetry`
- **group:tracing** — `tracing` + `tracing-subscriber` + `tracing-mock`（明示リスト: `tracing-opentelemetry` を OTel グループに残すため）
- **group:serde** — `serde` + `serde_*` + `serde-*`
- **group:assert_cmd** — `assert_cmd` + `predicates` + `predicates/*`
- **group:ratatui** — `ratatui` + `crossterm`
- **group:tokio** — `tokio` + `tokio-*`

除外: `reqwest` + `rustls`（独立性が高く個別ロールバックが必要）

## テスト計画

- [ ] renovate-config-validator --strict が通ること（CI で確認）
- [ ] dprint check が通ること（CI で確認）